### PR TITLE
Limit the number of scores in feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  10.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 10.days + i
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,6 +9,15 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
+
+    rng = Random.new
+    25.times do
+      Score.create!(
+        user: user2,
+        total_score: rng.rand(66..99),
+        played_at: '2021-02-02'
+      )
+    end
   end
 
   describe 'GET feed' do
@@ -19,12 +28,21 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
+    end
+
+    it 'should limit the number of retrieved scores to most recent 25' do
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/21

**Changes**

Limit feed to show the last 25 scores only.

**Before**

![Screenshot 2022-06-03 at 14 16 16](https://user-images.githubusercontent.com/104856809/171851143-8808a2b5-3303-4002-81bc-054cf8c06cc4.png)

**After**

![Screenshot 2022-06-03 at 14 16 49](https://user-images.githubusercontent.com/104856809/171851171-db50bf5a-8a7b-4c6d-bc0f-f2c2cd452cf3.png)
